### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1812,21 +1812,29 @@ export default class WeatherExtension extends Extension {
 
         let lat, lon, city, country;
 
-        if (url.includes('ipapi.co')) {
+        let parsedHost;
+        try {
+          parsedHost = new URL(url).host;
+        } catch (e) {
+          // If URL parsing fails, skip this URL
+          continue;
+        }
+
+        if (parsedHost === 'ipapi.co') {
           if (response.latitude && response.longitude) {
             lat = response.latitude;
             lon = response.longitude;
             city = response.city;
             country = response.country_name;
           }
-        } else if (url.includes('ip-api.com')) {
+        } else if (parsedHost === 'ip-api.com') {
           if (response.status === "success" && response.lat && response.lon) {
             lat = response.lat;
             lon = response.lon;
             city = response.city;
             country = response.country;
           }
-        } else if (url.includes('freegeoip.app')) {
+        } else if (parsedHost === 'freegeoip.app') {
           if (response.latitude && response.longitude) {
             lat = response.latitude;
             lon = response.longitude;


### PR DESCRIPTION
Potential fix for [https://github.com/Sanjai-Shaarugesh/Advanced-Weather-Companion/security/code-scanning/4](https://github.com/Sanjai-Shaarugesh/Advanced-Weather-Companion/security/code-scanning/4)

To fix the problem, we should parse the URL using the standard `URL` class and check the `host` property against an explicit list of allowed hosts. This ensures that only the intended domains are matched, and not arbitrary substrings elsewhere in the URL. Specifically, in the code block, replace all instances of `url.includes('ip-api.com')` (and similar checks for other services) with a check that parses the URL and compares its host to the expected value (e.g., `'ip-api.com'`). This change should be made in the relevant function, and the `URL` class should be used for parsing. Since this is JavaScript, and the code is running in GNOME Shell (GJS), the standard `URL` class is available and should be used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
